### PR TITLE
Add resources for 2020, fix README python example

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ lst2014 = Lohnsteuer2014(
     LZZ=2,
     KRV=2
 )
+lst2014.MAIN()
 print_lst(lst2014)
 
 ```

--- a/lstgen/pap.py
+++ b/lstgen/pap.py
@@ -78,6 +78,10 @@ PAP_RESOURCES = OrderedDict((
         '/interface/2019Version1.xhtml',
         '/javax.faces.resource/daten/xmls/Lohnsteuer2019.xml.xhtml'
     )),
+    ('2020', PapResource(
+        '/interface/2020Version1.xhtml',
+        '/javax.faces.resource/daten/xmls/Lohnsteuer2020.xml.xhtml'
+    )),
 ))
 
 


### PR DESCRIPTION
I just copy&pasted the 2019 resources and replaced 2019 by 2020. 
Also, in the README, the example in python with constructor arguments was missing the call to MAIN().