### PR TITLE
Golang calculator fails when using SetFactor

### DIFF
--- a/lstgen/generators/go.py
+++ b/lstgen/generators/go.py
@@ -148,7 +148,7 @@ class GoGenerator(JavaLikeGenerator):
             'BigDecimal[]': '[]'+self.bd_class,
             'BigDecimal': ''+self.bd_class,
             'int': 'int64',
-            'double': 'int64',
+            'double': 'float64',
         }[vartype]
 
     def _conv_list(self, node):


### PR DESCRIPTION
SetFactor would fail the calculator due to int64/float64 mismatch. This pull request fixes the issue.