### PR TITLE
Fixes for BigDecimal proxy class

### DIFF
--- a/lstgen/generators/php/BigDecimal.php
+++ b/lstgen/generators/php/BigDecimal.php
@@ -32,7 +32,7 @@ class BigDecimal {
     }
 
     public function setScale($scale, $rounding) {
-        return new BigDecimal($this->bd->withScale($scale, $rounding));
+        return new BigDecimal($this->bd->toScale($scale, $rounding));
     }
 
     public function add($other) {
@@ -44,7 +44,7 @@ class BigDecimal {
     }
 
     public function longValue() {
-        return $this->bd->toInteger();
+        return $this->bd->toInt();
     }
 
     public function floatValue() {

--- a/lstgen/generators/php/BigDecimal.php
+++ b/lstgen/generators/php/BigDecimal.php
@@ -3,7 +3,8 @@ use Brick\Math\RoundingMode as RoundingMode;
 
 /**
  * A proxy class to use BigDecimal methods
- * as they are found in PAP XML
+ * as they are found in PAP XML.
+ * Requires brick/math >= 0.6.0
  */
 class BigDecimal {
 


### PR DESCRIPTION
since v0.6.0 of brick/math:
* withScale was replaced by toScale
* toInteger was renamed toInt